### PR TITLE
Fix sandbox block IDs for Lodash example

### DIFF
--- a/examples/lodash docs/index.md
+++ b/examples/lodash docs/index.md
@@ -5,9 +5,14 @@
 Creates an array of elements split into groups the length of size. If array can't be split evenly, the final chunk will be the remaining elements.
 
 <BlockComponent
-  block={{"owner":"githubnext","repo":"blocks-examples","id":"sandbox-block","type":"file"}}
-context={{"path":"examples/lodash docs/example1.js"}}
-height={294}
+  block={{
+    owner: "githubnext",
+    repo: "blocks-examples",
+    id: "sandbox",
+    type: "file",
+  }}
+  context={{path: "examples/lodash docs/example1.js"}}
+  height={294}
 />
 
 `_.compact`
@@ -18,10 +23,11 @@ Creates an array with all falsey values removed. The values false, null, 0, "", 
   block={{
     owner: "githubnext",
     repo: "blocks-examples",
-    id: "sandbox-block",
+    id: "sandbox",
     type: "file",
   }}
   context={{path: "examples/lodash docs/example2.js"}}
+  height={294}
 />
 
 `_.concat`
@@ -32,8 +38,9 @@ Creates a new array concatenating array with any additional arrays and/or values
   block={{
     owner: "githubnext",
     repo: "blocks-examples",
-    id: "sandbox-block",
+    id: "sandbox",
     type: "file",
   }}
   context={{path: "examples/lodash docs/example3.js"}}
+  height={294}
 />


### PR DESCRIPTION
The block IDs for the Lodash examples are wrong and the `index.md` cannot find the sandbox block, this PR fixes that and updates to use the correct block ID.

### Before with ID sandbox-block

![blocks-not-found](https://user-images.githubusercontent.com/2221746/216697493-2f8b6fee-5364-42e9-a6ac-12ec59a298a4.png)

### After with ID sandbox

![blocks-found](https://user-images.githubusercontent.com/2221746/216697657-332ca258-07c3-4e34-9f17-0c0f8e49dcd4.png)
