### PR TITLE
Fixing markdown rendering

### DIFF
--- a/docs/Developing blocks/2 Building your first block.md
+++ b/docs/Developing blocks/2 Building your first block.md
@@ -12,6 +12,7 @@ Name your repository:
 
 <img width="801" alt="&quot;Create a new repository from blocks-template&quot; screen" src="https://user-images.githubusercontent.com/8978670/144893351-25b24bfa-3400-4e92-9a2a-618b3ac06a5e.png" />
 Finally, clone your newly-created repository, and you're ready to work.
+
 ## Developing locally
 
 ```bash


### PR DESCRIPTION
This markdown file renders ok on https://blocks.githubnext.com/githubnext/blocks/blob/main/docs/Developing%20blocks/2%20Building%20your%20first%20block.md :

![Screen Shot 2023-03-12 at 19 50 12](https://user-images.githubusercontent.com/47263/224559642-997111f0-d049-4b5b-9a7b-ae7f6b7a7755.png)

But on github it is not rendered properly https://github.com/githubnext/blocks/blob/main/docs/Developing%20blocks/2%20Building%20your%20first%20block.md 

![Screen Shot 2023-03-12 at 19 50 53](https://user-images.githubusercontent.com/47263/224559726-8bffaeaa-2933-488c-9b47-f4933e2e2625.png)

This should fix the rendering on GitHub

